### PR TITLE
Debug telegram application build error

### DIFF
--- a/code_image_bot.py
+++ b/code_image_bot.py
@@ -19,6 +19,10 @@ from telegram.ext import (
     ContextTypes,
     filters,
 )
+from telegram_compat import patch_updater_slots
+
+# Apply telegram compatibility patch for Python 3.13
+patch_updater_slots()
 
 # Configuration
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "YOUR_BOT_TOKEN_HERE")

--- a/code_image_bot_enhanced.py
+++ b/code_image_bot_enhanced.py
@@ -22,12 +22,18 @@ from telegram.ext import (
 )
 import logging
 
+from telegram_compat import patch_updater_slots
+
 # Setup logging
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     level=logging.INFO
 )
 logger = logging.getLogger(__name__)
+PTB_UPDATER_SLOTS_PATCHED = patch_updater_slots()
+
+if PTB_UPDATER_SLOTS_PATCHED:
+    logger.info("Applied python-telegram-bot Updater slot patch for Python 3.13 compatibility")
 
 # Configuration
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "YOUR_BOT_TOKEN_HERE")

--- a/telegram_compat.py
+++ b/telegram_compat.py
@@ -1,0 +1,27 @@
+"""
+Compatibility helpers for python-telegram-bot on newer Python runtimes.
+
+python-telegram-bot<=20.7 defines __slots__ on telegram.ext.Updater but forgets
+to reserve one for ``__polling_cleanup_cb``. Python 3.13 enforces slots more
+strictly and raises AttributeError when that attribute is assigned.
+"""
+
+
+def patch_updater_slots() -> bool:
+    """Ensure the Updater class has a slot for __polling_cleanup_cb."""
+    try:
+        from telegram.ext import _updater as _telegram_updater  # type: ignore
+    except Exception:
+        return False
+
+    missing_slot = "__polling_cleanup_cb"
+    slots = getattr(_telegram_updater.Updater, "__slots__", ())
+
+    if isinstance(slots, tuple) and missing_slot not in slots:
+        _telegram_updater.Updater.__slots__ = slots + (missing_slot,)
+        return True
+
+    return False
+
+
+__all__ = ["patch_updater_slots"]


### PR DESCRIPTION
Add a compatibility patch for `python-telegram-bot` to resolve `AttributeError` on Python 3.13.

The `AttributeError` occurs because `python-telegram-bot` versions <= 20.7 do not include `__polling_cleanup_cb` in the `__slots__` of `telegram.ext.Updater`. Python 3.13's stricter `__slots__` enforcement causes a crash when this attribute is accessed. The patch dynamically adds the missing slot to allow `Updater` instantiation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d89080b8-3725-464c-8697-9ddbb2f5facc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d89080b8-3725-464c-8697-9ddbb2f5facc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

