### PR TITLE
Fix telegram bot attribute error

### DIFF
--- a/telegram_compat.py
+++ b/telegram_compat.py
@@ -8,7 +8,7 @@ strictly and raises AttributeError when that attribute is assigned.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 from weakref import WeakKeyDictionary
 
 
@@ -25,12 +25,14 @@ def patch_updater_slots() -> bool:
 
     missing_slot = "__polling_cleanup_cb"
     slots = getattr(updater_cls, "__slots__", ())
+    slots_tuple = tuple(slots) if isinstance(slots, (tuple, list)) else ()
+    appended_slot = False
 
     # First try to append the missing slot like upstream should have done.
     if isinstance(slots, tuple) and missing_slot not in slots:
         try:
             updater_cls.__slots__ = slots + (missing_slot,)
-            return True
+            appended_slot = True
         except (TypeError, AttributeError):
             # Python refuses to mutate __slots__ post-class-creation; fall back
             # to a descriptor-based emulation below.
@@ -42,18 +44,31 @@ def patch_updater_slots() -> bool:
 
     if hasattr(updater_cls, mangled_name):
         # Already patched (descriptor exists) or upstream fixed it.
-        return False
+        return appended_slot
 
-    _cleanup_store: "WeakKeyDictionary[Any, Optional[Any]]" = WeakKeyDictionary()
+    if "__weakref__" in slots_tuple:
+        _cleanup_store: "WeakKeyDictionary[Any, Optional[Any]]" = WeakKeyDictionary()
 
-    def _get_cleanup_cb(self: Any) -> Optional[Any]:
-        return _cleanup_store.get(self)
+        def _get_cleanup_cb(self: Any) -> Optional[Any]:
+            return _cleanup_store.get(self)
 
-    def _set_cleanup_cb(self: Any, value: Optional[Any]) -> None:
-        _cleanup_store[self] = value
+        def _set_cleanup_cb(self: Any, value: Optional[Any]) -> None:
+            _cleanup_store[self] = value
 
-    def _del_cleanup_cb(self: Any) -> None:
-        _cleanup_store.pop(self, None)
+        def _del_cleanup_cb(self: Any) -> None:
+            _cleanup_store.pop(self, None)
+
+    else:
+        _cleanup_store_ids: "Dict[int, Optional[Any]]" = {}
+
+        def _get_cleanup_cb(self: Any) -> Optional[Any]:
+            return _cleanup_store_ids.get(id(self))
+
+        def _set_cleanup_cb(self: Any, value: Optional[Any]) -> None:
+            _cleanup_store_ids[id(self)] = value
+
+        def _del_cleanup_cb(self: Any) -> None:
+            _cleanup_store_ids.pop(id(self), None)
 
     setattr(updater_cls, mangled_name, property(
         _get_cleanup_cb, _set_cleanup_cb, _del_cleanup_cb,


### PR DESCRIPTION
Refactor `patch_updater_slots` to use a descriptor for `_Updater__polling_cleanup_cb` to ensure `python-telegram-bot` compatibility with Python 3.13.

The `AttributeError: 'Updater' object has no attribute '_Updater__polling_cleanup_cb'` occurs in Python 3.13 because `Updater.__slots__` becomes immutable after class creation, preventing direct addition of the missing slot. This change introduces a descriptor that emulates the attribute, using a `WeakKeyDictionary` or an `id`-based dictionary as a fallback, to correctly store `__polling_cleanup_cb`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff52f355-6c52-4206-8582-bcf90a111101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff52f355-6c52-4206-8582-bcf90a111101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

