### PR TITLE
Fix pillow build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-telegram-bot==20.7
-Pillow==10.1.0
+Pillow==11.0.0
 Pygments==2.17.2


### PR DESCRIPTION
Update Pillow to version 11.0.0 to resolve build errors on Python 3.13.

Pillow 10.1.0 failed to build from source on Python 3.13 due to a `KeyError: '__version__'`, as no prebuilt wheels were available for that specific Python version. Upgrading to 11.0.0 provides a compatible prebuilt wheel, eliminating the need for a source build.

---
<a href="https://cursor.com/background-agent?bcId=bc-73bc876f-0470-4a41-b7b9-fffe14386ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73bc876f-0470-4a41-b7b9-fffe14386ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

