### PR TITLE
Telegram bot message parsing error

### DIFF
--- a/code_image_bot_macos.py
+++ b/code_image_bot_macos.py
@@ -405,13 +405,13 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 ✨ *עיצוב מסוג macOS Window עם רקעים צבעוניים!*
 
 *פקודות זמינות:*
-/start - התחלה
-/theme - בחר ערכת נושא
-/language - בחר שפת תכנות
-/font - בחר גופן (Fira Code, JetBrains Mono ועוד)
-/toggle_numbers - הפעל/כבה מספור שורות
-/settings - הגדרות נוכחיות
-/help - עזרה
+  `/start` - התחלה
+  `/theme` - בחר ערכת נושא
+  `/language` - בחר שפת תכנות
+  `/font` - בחר גופן (Fira Code, JetBrains Mono ועוד)
+  `/toggle_numbers` - הפעל/כבה מספור שורות
+  `/settings` - הגדרות נוכחיות
+  `/help` - עזרה
 
 פשוט שלח קוד ותקבל תמונה מעוצבת! 🚀
 """
@@ -548,10 +548,10 @@ async def settings_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 🔢 מספור שורות: {'✅' if settings['show_line_numbers'] else '❌'}
 
 שנה הגדרות עם:
-/theme - שינוי ערכת נושא
-/language - שינוי שפת תכנות
-/font - שינוי גופן
-/toggle_numbers - הפעל/כבה מספור שורות
+  `/theme` - שינוי ערכת נושא
+  `/language` - שינוי שפת תכנות
+  `/font` - שינוי גופן
+  `/toggle_numbers` - הפעל/כבה מספור שורות
 """
     await update.message.reply_text(settings_text, parse_mode="Markdown")
 


### PR DESCRIPTION
Wrap Telegram bot command names in inline code blocks to fix Markdown parsing errors.

The `BadRequest` error "Can't parse entities" occurred because Telegram's Markdown parser misinterpreted underscores in command names (e.g., `/toggle_numbers`) as italic formatting, leading to malformed entities. Wrapping these commands in backticks (` `) forces them to be treated as literal code, bypassing Markdown interpretation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d09a407-d915-4c44-bee6-66e27c06d924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d09a407-d915-4c44-bee6-66e27c06d924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

